### PR TITLE
Fix Bullet Death Animation Bug

### DIFF
--- a/Ship/Prefabs/Bullet.tscn
+++ b/Ship/Prefabs/Bullet.tscn
@@ -1,12 +1,11 @@
-[gd_scene load_steps=20 format=3 uid="uid://bckeoopmbomi8"]
+[gd_scene load_steps=11 format=3 uid="uid://bckeoopmbomi8"]
 
 [ext_resource type="Script" path="res://Ship/Scripts/Components/Bullet.cs" id="1_ildc5"]
+[ext_resource type="PackedScene" uid="uid://bpi5xtyl1vg1v" path="res://Ship/Prefabs/BulletDeathAnimation.tscn" id="2_bqtpb"]
 [ext_resource type="Texture2D" uid="uid://bayrj47b7me0d" path="res://Assets/Bullets/SpaceShooterAssetPack_Projectiles.png" id="2_por51"]
 [ext_resource type="Script" path="res://Components/attackbox_component.gd" id="3_clinb"]
-[ext_resource type="Texture2D" uid="uid://1xyhviyhxvw" path="res://Assets/Bullets/bullet explotion.png" id="6_ctut0"]
 [ext_resource type="AudioStream" uid="uid://dwcx0lo8cd0hr" path="res://Assets/Audio/Shapeforms Audio Free Sound Effects/Sci Fi Weapons Cyberpunk Arsenal Preview/AUDIO/BLLTImpt_Hit Marker_07.wav" id="6_jhqyn"]
 [ext_resource type="Script" path="res://SingleRunAudio.cs" id="7_quqnm"]
-[ext_resource type="Script" path="res://Components/SingleRunAnimation.cs" id="7_uyts4"]
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_ifwps"]
 atlas = ExtResource("2_por51")
@@ -29,70 +28,14 @@ radius = 3.0
 [sub_resource type="CircleShape2D" id="CircleShape2D_a8mnx"]
 radius = 4.0
 
-[sub_resource type="AtlasTexture" id="AtlasTexture_t6o3h"]
-atlas = ExtResource("6_ctut0")
-region = Rect2(0, 0, 8, 8)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_fb1tb"]
-atlas = ExtResource("6_ctut0")
-region = Rect2(8, 0, 8, 8)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_33icf"]
-atlas = ExtResource("6_ctut0")
-region = Rect2(16, 0, 8, 8)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_tgvbe"]
-atlas = ExtResource("6_ctut0")
-region = Rect2(24, 0, 8, 8)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_cj7i8"]
-atlas = ExtResource("6_ctut0")
-region = Rect2(32, 0, 8, 8)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_tmfdh"]
-atlas = ExtResource("6_ctut0")
-region = Rect2(40, 0, 8, 8)
-
-[sub_resource type="AtlasTexture" id="AtlasTexture_yt1a1"]
-atlas = ExtResource("6_ctut0")
-region = Rect2(48, 0, 8, 8)
-
-[sub_resource type="SpriteFrames" id="SpriteFrames_4xrvy"]
-animations = [{
-"frames": [{
-"duration": 1.0,
-"texture": SubResource("AtlasTexture_t6o3h")
-}, {
-"duration": 1.0,
-"texture": SubResource("AtlasTexture_fb1tb")
-}, {
-"duration": 1.0,
-"texture": SubResource("AtlasTexture_33icf")
-}, {
-"duration": 1.0,
-"texture": SubResource("AtlasTexture_tgvbe")
-}, {
-"duration": 1.0,
-"texture": SubResource("AtlasTexture_cj7i8")
-}, {
-"duration": 1.0,
-"texture": SubResource("AtlasTexture_tmfdh")
-}, {
-"duration": 1.0,
-"texture": SubResource("AtlasTexture_yt1a1")
-}],
-"loop": false,
-"name": &"BulletExplosion",
-"speed": 20.0
-}]
-
 [node name="Bullet" type="CharacterBody2D" node_paths=PackedStringArray("timer", "attackboxComponent", "bulletSprite", "bulletHitAnimation", "onHitAudio")]
 script = ExtResource("1_ildc5")
 timer = NodePath("Timer")
 attackboxComponent = NodePath("AttackboxComponent")
 bulletSprite = NodePath("Sprite")
-bulletHitAnimation = NodePath("BulletDeathAnimation")
+bulletHitAnimation = NodePath("")
 onHitAudio = NodePath("HitAudio")
+bulletHitAnimationPrefab = ExtResource("2_bqtpb")
 
 [node name="Sprite" type="AnimatedSprite2D" parent="."]
 z_index = 1
@@ -113,17 +56,6 @@ debug_color = Color(0.902804, 0.278724, 0.346718, 0.42)
 [node name="HitAudio" type="AudioStreamPlayer2D" parent="."]
 stream = ExtResource("6_jhqyn")
 script = ExtResource("7_quqnm")
-
-[node name="BulletDeathAnimation" type="AnimatedSprite2D" parent="."]
-visible = false
-z_index = 2
-scale = Vector2(1.5, 1.5)
-sprite_frames = SubResource("SpriteFrames_4xrvy")
-animation = &"BulletExplosion"
-frame = 6
-frame_progress = 1.0
-script = ExtResource("7_uyts4")
-animationName = "BulletExplosion"
 
 [connection signal="area_entered" from="AttackboxComponent" to="." method="OnAttackboxAreaEntered"]
 [connection signal="body_entered" from="AttackboxComponent" to="." method="OnAttackBoxBodyEntered"]

--- a/Ship/Prefabs/BulletDeathAnimation.tscn
+++ b/Ship/Prefabs/BulletDeathAnimation.tscn
@@ -1,0 +1,71 @@
+[gd_scene load_steps=11 format=3 uid="uid://bpi5xtyl1vg1v"]
+
+[ext_resource type="Texture2D" uid="uid://1xyhviyhxvw" path="res://Assets/Bullets/bullet explotion.png" id="1_njfrs"]
+[ext_resource type="Script" path="res://Components/SingleRunAnimation.cs" id="2_7isbs"]
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_t6o3h"]
+atlas = ExtResource("1_njfrs")
+region = Rect2(0, 0, 8, 8)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_fb1tb"]
+atlas = ExtResource("1_njfrs")
+region = Rect2(8, 0, 8, 8)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_33icf"]
+atlas = ExtResource("1_njfrs")
+region = Rect2(16, 0, 8, 8)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_tgvbe"]
+atlas = ExtResource("1_njfrs")
+region = Rect2(24, 0, 8, 8)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_cj7i8"]
+atlas = ExtResource("1_njfrs")
+region = Rect2(32, 0, 8, 8)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_tmfdh"]
+atlas = ExtResource("1_njfrs")
+region = Rect2(40, 0, 8, 8)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_yt1a1"]
+atlas = ExtResource("1_njfrs")
+region = Rect2(48, 0, 8, 8)
+
+[sub_resource type="SpriteFrames" id="SpriteFrames_0r8k6"]
+animations = [{
+"frames": [{
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_t6o3h")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_fb1tb")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_33icf")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_tgvbe")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_cj7i8")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_tmfdh")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_yt1a1")
+}],
+"loop": false,
+"name": &"BulletExplosion",
+"speed": 20.0
+}]
+
+[node name="BulletDeathAnimation" type="AnimatedSprite2D"]
+z_index = 2
+scale = Vector2(1.5, 1.5)
+sprite_frames = SubResource("SpriteFrames_0r8k6")
+animation = &"BulletExplosion"
+frame = 6
+frame_progress = 1.0
+script = ExtResource("2_7isbs")
+animationName = "BulletExplosion"

--- a/Ship/Prefabs/Laser.tscn
+++ b/Ship/Prefabs/Laser.tscn
@@ -1,10 +1,13 @@
-[gd_scene load_steps=16 format=3 uid="uid://cum7a4fabqn8w"]
+[gd_scene load_steps=19 format=3 uid="uid://cum7a4fabqn8w"]
 
 [ext_resource type="Script" path="res://Ship/Scripts/Components/Bullet.cs" id="1_nqjkm"]
 [ext_resource type="Texture2D" uid="uid://dquwdhpf56fjv" path="res://Assets/Bullets/Lasers.png" id="2_paqed"]
+[ext_resource type="PackedScene" uid="uid://bpi5xtyl1vg1v" path="res://Ship/Prefabs/BulletDeathAnimation.tscn" id="2_rgtak"]
 [ext_resource type="Script" path="res://Components/attackbox_component.gd" id="3_ulkoc"]
 [ext_resource type="Texture2D" uid="uid://1xyhviyhxvw" path="res://Assets/Bullets/bullet explotion.png" id="4_ovyox"]
 [ext_resource type="Script" path="res://Components/SingleRunAnimation.cs" id="5_elk2p"]
+[ext_resource type="AudioStream" uid="uid://dwcx0lo8cd0hr" path="res://Assets/Audio/Shapeforms Audio Free Sound Effects/Sci Fi Weapons Cyberpunk Arsenal Preview/AUDIO/BLLTImpt_Hit Marker_07.wav" id="7_cblig"]
+[ext_resource type="Script" path="res://SingleRunAudio.cs" id="8_puuca"]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_c8rxq"]
 size = Vector2(2, 6)
@@ -69,12 +72,14 @@ animations = [{
 "speed": 5.0
 }]
 
-[node name="Laser" type="CharacterBody2D" node_paths=PackedStringArray("timer", "attackboxComponent", "bulletSprite", "bulletHitAnimation")]
+[node name="Laser" type="CharacterBody2D" node_paths=PackedStringArray("timer", "attackboxComponent", "bulletSprite", "bulletHitAnimation", "onHitAudio")]
 script = ExtResource("1_nqjkm")
 timer = NodePath("Timer")
 attackboxComponent = NodePath("AttackboxComponent")
 bulletSprite = NodePath("Sprite")
 bulletHitAnimation = NodePath("SingleRunAnimation")
+onHitAudio = NodePath("HitAudio")
+bulletHitAnimationPrefab = ExtResource("2_rgtak")
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
 z_index = -2
@@ -106,6 +111,10 @@ animation = &"BulletExplosion"
 frame_progress = 0.9432
 script = ExtResource("5_elk2p")
 animationName = "BulletExplosion"
+
+[node name="HitAudio" type="AudioStreamPlayer2D" parent="."]
+stream = ExtResource("7_cblig")
+script = ExtResource("8_puuca")
 
 [connection signal="area_entered" from="AttackboxComponent" to="." method="OnAttackboxAreaEntered"]
 [connection signal="body_entered" from="AttackboxComponent" to="." method="OnAttackBoxBodyEntered"]

--- a/Ship/Scripts/Components/Bullet.cs
+++ b/Ship/Scripts/Components/Bullet.cs
@@ -16,9 +16,9 @@ public partial class Bullet : CharacterBody2D
     private Node2D bulletSprite;
     [ExportCategory("On-Hit Configuration")]
     [Export]
-    private SingleRunAnimation bulletHitAnimation;
-    [Export]
 	private SingleRunAudio onHitAudio;
+    [Export]
+    private PackedScene bulletHitAnimationPrefab;
 
     public float speed { get; set; }
 
@@ -40,14 +40,27 @@ public partial class Bullet : CharacterBody2D
     public void OnAttackboxAreaEntered(Area2D area)
     {
         if (area.GetParent() == this) { return; }
+
+        OnHitFX();
     }
 
     public void OnAttackBoxBodyEntered(Node2D node2D)
     {
         if (node2D == this) { return; }
+
+        OnHitFX();
     }
 
     private void DestroyBullet(){
+
+        // Bullet Death VFX
+        AnimatedSprite2D bulletDeathAnimation = bulletHitAnimationPrefab.Instantiate() as AnimatedSprite2D;
+        bulletDeathAnimation.GlobalPosition = GlobalPosition;
+        bulletDeathAnimation.GlobalRotation = GlobalRotation;
+        bulletDeathAnimation.Play();
+        GetTree().CurrentScene.AddChild(bulletDeathAnimation);
+
+        // Destroy Bullet
         CallDeferred("queue_free");
     }
 
@@ -57,11 +70,7 @@ public partial class Bullet : CharacterBody2D
     private void OnHitFX(){
         // SFX
         onHitAudio.PlayOnce();
-
-        // VFX
-        bulletSprite.Visible = false;
-        bulletHitAnimation.AnimationFinished += DestroyBullet;
-        bulletHitAnimation.Visible = true;
-        bulletHitAnimation.Play();
+      
+        DestroyBullet();
     }
 }


### PR DESCRIPTION
# Context
Fixed the bug where the bullet death animation causes the bullet to push objects. The laser bullet was missing the audio, which was added.

# Additions
 * A separate prefab for the bullet death animation

# Modified
* Laser.tscn to add the hit audio.
* Bullet.cs
* Bullet.tscn to detach the bullet death animation.
* 
# Removed

# Asset Change

# Bug

# Bug Fix
* Fixes the improper collision of bullets hitting objects. The bug caused to push the object away, but now the bullet is destroyed and the animation is played.
