### PR TITLE
Money system

### DIFF
--- a/Misc/Economy/CreditsManager.cs
+++ b/Misc/Economy/CreditsManager.cs
@@ -12,7 +12,6 @@ public partial class CreditsManager : Node
     public bool TryDecreaseCredits(float decreaseAmount){
         if(HasEnoughMoney(decreaseAmount)){
             TotalCredits -= decreaseAmount;
-            GD.Print(TotalCredits);
             EmitSignal(SignalName.CreditsChanged, TotalCredits);
             return true;
         }

--- a/Misc/Economy/CreditsManager.cs
+++ b/Misc/Economy/CreditsManager.cs
@@ -1,0 +1,32 @@
+using Godot;
+using System;
+
+[GlobalClass]
+public partial class CreditsManager : Node
+{
+    [Signal]
+    public delegate void CreditsChangedEventHandler(float totalCredits);
+
+    public float TotalCredits {get; private set;}
+
+    public bool TryDecreaseCredits(float decreaseAmount){
+        if(HasEnoughMoney(decreaseAmount)){
+            TotalCredits -= decreaseAmount;
+            GD.Print(TotalCredits);
+            EmitSignal(SignalName.CreditsChanged, TotalCredits);
+            return true;
+        }
+        else{
+            return false;
+        }
+    }
+
+    public void AddCredits(float increaseAmount){
+        TotalCredits += increaseAmount;
+        EmitSignal(SignalName.CreditsChanged, TotalCredits);
+    }
+
+    public bool HasEnoughMoney(float priceToCheck){
+        return priceToCheck <= TotalCredits;
+    }
+}

--- a/Misc/Economy/CreditsPouch.cs
+++ b/Misc/Economy/CreditsPouch.cs
@@ -1,0 +1,24 @@
+using Godot;
+using System;
+
+[GlobalClass]
+public partial class CreditsPouch : Label
+{
+	public override void _Ready()
+	{
+		ConfigurePouch(Game.Instance.PlayerShip);
+	}
+
+    public void ConfigurePouch(PlayerShip playerShip)
+    {
+        if(playerShip != null) 
+        {
+            playerShip.CreditsChanged -= UpdateCreditsDisplay;
+        }
+        playerShip.CreditsChanged += UpdateCreditsDisplay;
+    }
+
+	public void UpdateCreditsDisplay(float totalCredits){
+		Text = $"{totalCredits}";
+	}
+}

--- a/Misc/Economy/CreditsTestScene.tscn
+++ b/Misc/Economy/CreditsTestScene.tscn
@@ -1,0 +1,67 @@
+[gd_scene load_steps=5 format=3 uid="uid://b1c7noeo65k3p"]
+
+[ext_resource type="PackedScene" uid="uid://bnebyucsoprtc" path="res://Scenes/background.tscn" id="1_gky4p"]
+[ext_resource type="Script" path="res://Ship/Scripts/player_spawner.gd" id="2_ggtuj"]
+[ext_resource type="Theme" uid="uid://do1kf4d65vh5b" path="res://UI/Styles/start_menu.tres" id="3_m4nla"]
+[ext_resource type="Script" path="res://Misc/Economy/credits_test.gd" id="3_rr32r"]
+
+[node name="CreditsTestScene" type="Node2D"]
+
+[node name="Background" parent="." instance=ExtResource("1_gky4p")]
+
+[node name="Player" type="Node2D" parent="."]
+script = ExtResource("2_ggtuj")
+
+[node name="CanvasLayer" type="CanvasLayer" parent="."]
+
+[node name="Credits Test" type="Control" parent="CanvasLayer"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_right = -1112.0
+offset_bottom = -608.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("3_rr32r")
+
+[node name="Buy Nuggets" type="Button" parent="CanvasLayer/Credits Test"]
+layout_mode = 0
+offset_left = 785.0
+offset_top = 219.0
+offset_right = 1136.0
+offset_bottom = 280.0
+theme = ExtResource("3_m4nla")
+text = "McDonalds McNuggets:  150 Credits"
+
+[node name="Add Credits" type="Button" parent="CanvasLayer/Credits Test"]
+layout_mode = 0
+offset_left = 797.0
+offset_top = 320.0
+offset_right = 1132.0
+offset_bottom = 381.0
+theme = ExtResource("3_m4nla")
+text = "Add 200 Credits"
+
+[node name="credits_check" type="Label" parent="CanvasLayer/Credits Test"]
+layout_mode = 1
+anchors_preset = -1
+anchor_bottom = 16.159
+offset_left = 886.0
+offset_top = 183.0
+offset_right = 1033.0
+offset_bottom = -440.36
+text = "Insufficient Credits"
+
+[node name="nuggets amounts" type="Label" parent="CanvasLayer/Credits Test"]
+layout_mode = 1
+anchors_preset = -1
+anchor_bottom = 16.159
+offset_left = 873.0
+offset_top = 64.0
+offset_right = 1030.0
+offset_bottom = -559.36
+text = "You have 0 Nuggets."
+
+[connection signal="pressed" from="CanvasLayer/Credits Test/Buy Nuggets" to="CanvasLayer/Credits Test" method="_on_buy_McNuggets_pressed"]
+[connection signal="pressed" from="CanvasLayer/Credits Test/Add Credits" to="CanvasLayer/Credits Test" method="_on_add_credits_pressed"]

--- a/Misc/Economy/credits_test.gd
+++ b/Misc/Economy/credits_test.gd
@@ -1,0 +1,32 @@
+extends Control
+
+@export var add_credits_amount = 200
+@export var mcnuggets_price = 150
+
+@onready var player_ship = Game.PlayerShip
+
+@onready var credits_check_label: Label = $credits_check
+@onready var nuggets_amounts_label: Label = $"nuggets amounts"
+
+var nuggets = 0
+
+# Called every frame. 'delta' is the elapsed time since the previous frame.
+func _process(delta: float) -> void:
+	if(player_ship != null):
+		var has_enough = player_ship.HasEnoughCredits(mcnuggets_price)
+		
+		if(has_enough):
+			credits_check_label.text = "You have enough."
+		else:
+			credits_check_label.text = "You do not have enough credits."
+
+func _on_buy_McNuggets_pressed() -> void:
+	var purchaseValid = player_ship.TryTakeCredits(mcnuggets_price)
+	
+	if (purchaseValid):
+		nuggets +=1
+		nuggets_amounts_label.text = "You have " + str(nuggets) + " nuggets."
+		
+
+func _on_add_credits_pressed() -> void:
+	player_ship.AddCredits(add_credits_amount)

--- a/Ship/Scripts/PlayerShip.cs
+++ b/Ship/Scripts/PlayerShip.cs
@@ -17,6 +17,9 @@ public partial class PlayerShip : Ship, IShip
 	[Signal]
 	public delegate void WeaponMenuToggledEventHandler(bool isOpen);
 
+	[Signal]
+    public delegate void CreditsChangedEventHandler(float totalCredits);
+
 	[Export]
 	private Shield shield;
 
@@ -26,6 +29,8 @@ public partial class PlayerShip : Ship, IShip
 	private PowerManager powerManager;
 	private CargoManager cargoManager = new();
 	private FuelManager fuelManager = new();
+
+	private CreditsManager creditsManager = new();
 
 	private bool weaponMenuIsOpen = false;
 
@@ -51,6 +56,8 @@ public partial class PlayerShip : Ship, IShip
 
 		shield.ShieldHit += UsePowerChunk;
 		blinking.Blink += UsePowerChunk;
+
+		creditsManager.CreditsChanged += (totalCredits) => EmitSignal(SignalName.CreditsChanged, totalCredits);
 	}
 
 	public override void _PhysicsProcess(double delta)
@@ -204,5 +211,19 @@ public partial class PlayerShip : Ship, IShip
 	public void CollectCargo(Cargo cargo)
 	{
 		cargoManager.AddCargo(cargo);
+	}
+
+	/// Credits Section
+	
+	public void AddCredits(float collectedAmount){
+		creditsManager.AddCredits(collectedAmount);
+	}
+
+	public bool TryTakeCredits(float decreaseAmount){
+		return creditsManager.TryDecreaseCredits(decreaseAmount);
+	}
+
+	public bool HasEnoughCredits(float priceToCheck){
+		return creditsManager.HasEnoughMoney(priceToCheck);
 	}
 }

--- a/Ship/Scripts/PlayerShip.cs
+++ b/Ship/Scripts/PlayerShip.cs
@@ -213,16 +213,30 @@ public partial class PlayerShip : Ship, IShip
 		cargoManager.AddCargo(cargo);
 	}
 
-	/// Credits Section
+	//Credits Section
 	
-	public void AddCredits(float collectedAmount){
-		creditsManager.AddCredits(collectedAmount);
+	/// <summary>
+	/// Add the credits currency to the player.
+	/// </summary>
+	/// <param name="amountToAdd">Amount of credits to add</param>
+	public void AddCredits(float amountToAdd){
+		creditsManager.AddCredits(amountToAdd);
 	}
 
+	/// <summary>
+	/// Removing credits from the players available credits.
+	/// </summary>
+	/// <param name="decreaseAmount">Amount to take away.</param>
+	/// <returns>Returns wether this action has succeeded or not. A false means that no money was taking away.</returns>
 	public bool TryTakeCredits(float decreaseAmount){
 		return creditsManager.TryDecreaseCredits(decreaseAmount);
 	}
 
+	/// <summary>
+	/// A check to see wether the player has enough credits to purchase something with the given price.
+	/// </summary>
+	/// <param name="priceToCheck"></param>
+	/// <returns></returns>
 	public bool HasEnoughCredits(float priceToCheck){
 		return creditsManager.HasEnoughMoney(priceToCheck);
 	}

--- a/UI/Scenes/HUD.tscn
+++ b/UI/Scenes/HUD.tscn
@@ -1,8 +1,9 @@
-[gd_scene load_steps=6 format=3 uid="uid://6kl08g15r5ty"]
+[gd_scene load_steps=7 format=3 uid="uid://6kl08g15r5ty"]
 
 [ext_resource type="PackedScene" uid="uid://ddunimkojubhv" path="res://UI/Scenes/PowerBar.tscn" id="1_unlij"]
 [ext_resource type="Script" path="res://UI/Scripts/FuelBar.cs" id="2_4xhg0"]
 [ext_resource type="PackedScene" uid="uid://ot5etuqeaw7o" path="res://UI/Scenes/weapon_menu.tscn" id="3_m2vvt"]
+[ext_resource type="Script" path="res://Misc/Economy/CreditsPouch.cs" id="4_cf0du"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_rmkss"]
 bg_color = Color(0.2754, 0.51, 0.36533, 1)
@@ -64,3 +65,25 @@ text = "Fuel"
 metadata/_edit_use_anchors_ = true
 
 [node name="weapon_menu" parent="." instance=ExtResource("3_m2vvt")]
+
+[node name="Credits" type="Label" parent="."]
+anchors_preset = 9
+anchor_bottom = 1.0
+offset_left = 63.0
+offset_top = 475.0
+offset_right = 118.0
+offset_bottom = -150.0
+grow_vertical = 2
+text = "Credits"
+
+[node name="CreditsAmount" type="Label" parent="."]
+anchors_preset = 9
+anchor_bottom = 1.0
+offset_left = 143.0
+offset_top = 478.0
+offset_right = 370.0
+offset_bottom = -147.0
+grow_vertical = 2
+text = "0
+"
+script = ExtResource("4_cf0du")


### PR DESCRIPTION
# Context
Added a simple money system. The playership contains a CreditsManager, where the total amount of credits is saved. Through public methods in the playership script, actions such as adding and removing credits can be done. 

There is an additional method to check wether the player has enough credits compared to a given price. The idea here is to perhaps use this for shops as pre check for purchaseable items. This would allow the shop to already present to the player that he/she is unable to buy it.

Currently, I added a label for the credits in the HUD prefab, so this is available in every other scene. The amount on this label is changed through a signal.

A test scene has been added, where you can press buttons to add and decrease credits. The test script and scene need to be deleted later.

# Additions
* CreditsManager.cs is the main script where the adding and taking away is done.
* CreditsPouch.cs is used to update the UI for the credits.
* Credits_test.gd is used for the test scene to make the interactions work properly. This needs to be deleted later.
* CreditsTestScene.tscn

# Modified
* PlayerShip: Added the public methods to interact with the credits manager. 
* HUD.tscn: Added the Credits to the UI

# Removed
Nothing

# Asset Change
Nothing

# Bug
Not that I know off.
