### PR TITLE
fixed rotation lost on destroy

### DIFF
--- a/Ship/Scripts/Components/ShipComponent.cs
+++ b/Ship/Scripts/Components/ShipComponent.cs
@@ -83,6 +83,7 @@ public partial class ShipComponent : CharacterBody2D
         sprite.FlipH = IsMirrored;
         healthComponent.Call("set_component", this.data.MaxHealth, this.data.Defense);
         destroyedSprite.Texture = this.data.DestroyedSprite;
+        destroyedSprite.FlipH = IsMirrored;
         TopAttachable = this.data.TopAttachable;
         BottomAttachable = this.data.BottomAttachable;
         RightAttachable = this.data.RightAttachable;


### PR DESCRIPTION
# Context
Fixing rotation lost on destroy bug. Turned out that rotation was working fine but the flipping of sprites was being lost.
# Bug Fix
- fixes #105 
