### PR TITLE
ship components can be now put in hubs

### DIFF
--- a/Scenes/open_space.tscn
+++ b/Scenes/open_space.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=21 format=3 uid="uid://ck7jschg6olwg"]
+[gd_scene load_steps=45 format=3 uid="uid://ck7jschg6olwg"]
 
 [ext_resource type="PackedScene" uid="uid://bnebyucsoprtc" path="res://Scenes/background.tscn" id="1_dsj0j"]
 [ext_resource type="Texture2D" uid="uid://bisny8ancsbfm" path="res://Assets/Hazzards/Blackhole/Blackhole.png" id="2_e8ctp"]
@@ -9,11 +9,35 @@
 [ext_resource type="PackedScene" uid="uid://2hmchkli54en" path="res://Structures/Station 1.tscn" id="4_gkyib"]
 [ext_resource type="PackedScene" uid="uid://b17scoqxflc5w" path="res://Structures/Props/Interactables/interactable_node_reveal.tscn" id="4_r8lle"]
 [ext_resource type="PackedScene" uid="uid://mrios312noqm" path="res://Structures/Props/Interactables/Credit reward/Credit_reward.tscn" id="5_8jmmm"]
+[ext_resource type="Resource" uid="uid://d2qdwbbvt725r" path="res://Resources/ShipData/Tali/Tali Cockpit.tres" id="7_wamet"]
+[ext_resource type="Resource" uid="uid://b8ag0jd3e44wa" path="res://Resources/ShipData/Tali/Tali Fuel Tank.tres" id="8_5i5c0"]
 [ext_resource type="Script" path="res://Ship/Scripts/player_spawner.gd" id="8_a0yns"]
+[ext_resource type="Resource" uid="uid://qiucae7gxati" path="res://Resources/ShipData/Tali/Tali Generator.tres" id="9_ijx3h"]
+[ext_resource type="Resource" uid="uid://bnpfn7k64mki7" path="res://Resources/ShipData/Tali/Tali Gun.tres" id="10_mjbu0"]
+[ext_resource type="Resource" uid="uid://cx1in1n1c03cl" path="res://Resources/ShipData/Tali/Tali Hull.tres" id="11_jjye7"]
 [ext_resource type="PackedScene" uid="uid://bvkkqplsiju1m" path="res://Hazards/Comet/Comet_Disable_Area.tscn" id="11_kd5fh"]
 [ext_resource type="Script" path="res://UI/Scripts/WarningWalls.cs" id="11_ogu1x"]
 [ext_resource type="Texture2D" uid="uid://bblf5h8yefb5" path="res://Assets/Other/warningSign.png" id="12_87wu5"]
 [ext_resource type="Script" path="res://Scenes/DeathWalls.cs" id="12_773b4"]
+[ext_resource type="Resource" uid="uid://b1n3cc6ubv315" path="res://Resources/ShipData/Tali/Tali Thruster.tres" id="12_q2id4"]
+[ext_resource type="Resource" uid="uid://d2k8teoaq2t8m" path="res://Resources/ShipData/O'mano/O'Mano Cockpit.tres" id="13_mtmd0"]
+[ext_resource type="Resource" uid="uid://cek8h02am0hxa" path="res://Resources/ShipData/O'mano/O'Mano Fuel Tank.tres" id="14_0c4gh"]
+[ext_resource type="Resource" uid="uid://cg2ve7s4s4hmx" path="res://Resources/ShipData/O'mano/O'Mano Generator.tres" id="15_3v0w1"]
+[ext_resource type="Resource" uid="uid://b70fhd1e4anfr" path="res://Resources/ShipData/O'mano/O'Mano Gun.tres" id="16_g3mh2"]
+[ext_resource type="Resource" uid="uid://rdkxlekri7yj" path="res://Resources/ShipData/O'mano/O'Mano Hull.tres" id="17_vbn6v"]
+[ext_resource type="Resource" uid="uid://b0cu6intmhaph" path="res://Resources/ShipData/O'mano/O'Mano Thruster.tres" id="18_kdlsv"]
+[ext_resource type="Resource" uid="uid://d1wj1c1q8xjf4" path="res://Resources/ShipData/Arzo/Arzo Cockpit.tres" id="19_0p6ks"]
+[ext_resource type="Resource" uid="uid://btsesvosi62ol" path="res://Resources/ShipData/Arzo/Arzo Fuel Tank.tres" id="20_nrjed"]
+[ext_resource type="Resource" uid="uid://bn45f5ywhhqpf" path="res://Resources/ShipData/Arzo/Arzo Generator.tres" id="21_kdabr"]
+[ext_resource type="Resource" uid="uid://50ho5luwhv1m" path="res://Resources/ShipData/Arzo/Arzo Gun.tres" id="22_qq4sl"]
+[ext_resource type="Resource" uid="uid://bbcg4mu0p2j8l" path="res://Resources/ShipData/Arzo/Arzo Hull.tres" id="23_kqfv4"]
+[ext_resource type="Resource" uid="uid://dc0h7q8fch0n0" path="res://Resources/ShipData/Arzo/Arzo Thruster.tres" id="24_domeo"]
+[ext_resource type="Resource" uid="uid://c261yp5mbqbms" path="res://Resources/ShipData/Zentri/Zentri Cockpit.tres" id="25_r878d"]
+[ext_resource type="Resource" uid="uid://dr6qampoysb5j" path="res://Resources/ShipData/Zentri/Zentri Fuel Tank.tres" id="26_0u3hf"]
+[ext_resource type="Resource" uid="uid://b6wi7lh5sy378" path="res://Resources/ShipData/Zentri/Zentri Generator.tres" id="27_p02e3"]
+[ext_resource type="Resource" uid="uid://dhobp4c3cdd6k" path="res://Resources/ShipData/Zentri/Zentri Gun.tres" id="28_bdphw"]
+[ext_resource type="Resource" uid="uid://dpvpxoa7yo0b5" path="res://Resources/ShipData/Zentri/Zentri Hull.tres" id="29_6x75j"]
+[ext_resource type="Resource" uid="uid://cl6j86mc6ya4t" path="res://Resources/ShipData/Zentri/Zentri Thruster.tres" id="30_imron"]
 
 [sub_resource type="CircleShape2D" id="CircleShape2D_fi5be"]
 radius = 220.792
@@ -80,7 +104,7 @@ loop = true
 autoplay = true
 
 [node name="Player" type="Node2D" parent="."]
-position = Vector2(838, 344)
+position = Vector2(4427, 2207)
 script = ExtResource("8_a0yns")
 
 [node name="Comet_tracker" type="Node" parent="."]
@@ -288,24 +312,24 @@ direction = Vector2(40, 40)
 [node name="Stations" type="Node2D" parent="."]
 
 [node name="Station" parent="Stations" instance=ExtResource("4_gkyib")]
-process_mode = 3
 position = Vector2(938, 1018)
 scale = Vector2(4.97656, 4.97656)
+Datas = Array[Object]([ExtResource("7_wamet"), ExtResource("8_5i5c0"), ExtResource("9_ijx3h"), ExtResource("10_mjbu0"), ExtResource("11_jjye7"), ExtResource("12_q2id4")])
 
 [node name="Station2" parent="Stations" instance=ExtResource("4_gkyib")]
-process_mode = 3
 position = Vector2(-104, 4008)
 scale = Vector2(4.97656, 4.97656)
+Datas = Array[Object]([ExtResource("13_mtmd0"), ExtResource("14_0c4gh"), ExtResource("15_3v0w1"), ExtResource("16_g3mh2"), ExtResource("17_vbn6v"), ExtResource("18_kdlsv")])
 
 [node name="Station3" parent="Stations" instance=ExtResource("4_gkyib")]
-process_mode = 3
 position = Vector2(2862, -1357)
 scale = Vector2(4.97656, 4.97656)
+Datas = Array[Object]([ExtResource("19_0p6ks"), ExtResource("20_nrjed"), ExtResource("21_kdabr"), ExtResource("22_qq4sl"), ExtResource("23_kqfv4"), ExtResource("24_domeo")])
 
 [node name="Station4" parent="Stations" instance=ExtResource("4_gkyib")]
-process_mode = 3
 position = Vector2(4830, 2237)
 scale = Vector2(4.97656, 4.97656)
+Datas = Array[Object]([ExtResource("25_r878d"), ExtResource("26_0u3hf"), ExtResource("27_p02e3"), ExtResource("28_bdphw"), ExtResource("29_6x75j"), ExtResource("30_imron")])
 
 [node name="Interactables" type="Node2D" parent="."]
 script = ExtResource("3_sun44")

--- a/Structures/Station 1.tscn
+++ b/Structures/Station 1.tscn
@@ -14,6 +14,7 @@ texture = ExtResource("1_cvbei")
 region_enabled = true
 region_rect = Rect2(0, 0, 64, 64)
 script = ExtResource("2_x4w6x")
+Datas = Array[Object]([])
 menu = NodePath("CanvasLayer/StationMenu")
 popup = NodePath("CanvasLayer/PopUp")
 
@@ -45,9 +46,10 @@ text = "Press F to enter HUB"
 horizontal_alignment = 1
 vertical_alignment = 1
 
-[node name="StationMenu" parent="CanvasLayer" instance=ExtResource("3_3d0kp")]
+[node name="StationMenu" parent="CanvasLayer" node_paths=PackedStringArray("stationHub") instance=ExtResource("3_3d0kp")]
 process_mode = 0
 visible = false
+stationHub = NodePath("../..")
 
 [connection signal="body_entered" from="Area2D" to="." method="OnBodyEntered"]
 [connection signal="body_exited" from="Area2D" to="." method="OnBodyExited"]

--- a/Structures/Station.cs
+++ b/Structures/Station.cs
@@ -3,6 +3,8 @@ using Godot;
 
 public partial class Station : Sprite2D
 {
+	[Export]
+	public ShipComponentData[] Datas { get; private set; }
 	private bool isOnBody = false;
 
 	private Tween tween;

--- a/UI/Scenes/StationMenu.tscn
+++ b/UI/Scenes/StationMenu.tscn
@@ -1,14 +1,10 @@
-[gd_scene load_steps=11 format=3 uid="uid://dwnag7qev53p4"]
+[gd_scene load_steps=7 format=3 uid="uid://dwnag7qev53p4"]
 
 [ext_resource type="FontFile" uid="uid://dm3da8vv2pdur" path="res://UI/Styles/Early GameBoy.ttf" id="1_lag8a"]
 [ext_resource type="Script" path="res://UI/Scripts/Menu.cs" id="2_oc8j1"]
 [ext_resource type="Script" path="res://UI/Scripts/Tabs.cs" id="3_fyd7s"]
 [ext_resource type="Script" path="res://Resources/Scripts/player_ship_save.gd" id="6_bhwvy"]
-[ext_resource type="Resource" uid="uid://d1wj1c1q8xjf4" path="res://Resources/ShipData/Arzo/Arzo Cockpit.tres" id="6_vda0v"]
-[ext_resource type="Resource" uid="uid://bn45f5ywhhqpf" path="res://Resources/ShipData/Arzo/Arzo Generator.tres" id="8_h0ajs"]
 [ext_resource type="PackedScene" uid="uid://bek4qr7p7b0d7" path="res://UI/ShipBuilder/Scenes/ShipBuilderTab.tscn" id="9_kosew"]
-[ext_resource type="Resource" uid="uid://50ho5luwhv1m" path="res://Resources/ShipData/Arzo/Arzo Gun.tres" id="9_oi2fc"]
-[ext_resource type="Resource" uid="uid://dc0h7q8fch0n0" path="res://Resources/ShipData/Arzo/Arzo Thruster.tres" id="11_gvtg5"]
 
 [sub_resource type="Theme" id="Theme_t0xj3"]
 default_font = ExtResource("1_lag8a")
@@ -26,7 +22,6 @@ grow_vertical = 2
 mouse_filter = 1
 theme = SubResource("Theme_t0xj3")
 script = ExtResource("2_oc8j1")
-datas = Array[Object]([ExtResource("6_vda0v"), ExtResource("8_h0ajs"), ExtResource("11_gvtg5"), ExtResource("9_oi2fc")])
 shipSaverClass = ExtResource("6_bhwvy")
 
 [node name="ColorRect" type="ColorRect" parent="."]
@@ -75,8 +70,9 @@ size_flags_vertical = 3
 current_tab = 0
 script = ExtResource("3_fyd7s")
 
-[node name="Build Ship" parent="MarginContainer/VBoxContainer/Tabs/TabContainer" instance=ExtResource("9_kosew")]
+[node name="Build Ship" parent="MarginContainer/VBoxContainer/Tabs/TabContainer" node_paths=PackedStringArray("stationMenu") instance=ExtResource("9_kosew")]
 layout_mode = 2
+stationMenu = NodePath("../../../../..")
 metadata/_tab_index = 0
 
 [node name="Buy Parts" type="HBoxContainer" parent="MarginContainer/VBoxContainer/Tabs/TabContainer"]

--- a/UI/Scripts/Menu.cs
+++ b/UI/Scripts/Menu.cs
@@ -2,12 +2,22 @@ using Godot;
 
 public partial class Menu : Control
 {
-	[Export]
-	private ShipComponentData[] datas;
+	[Signal]
+	public delegate void OnReadyFinishedEventHandler();
 	[Signal]
 	public delegate void QuitPressedEventHandler();
 	[Export]
 	private Resource shipSaverClass;
+	[Export]
+	public Station stationHub;
+	public ShipComponentData[] Datas { get; private set; }
+
+	public override void _Ready()
+	{
+		GD.Print("Items: " + stationHub.Datas.Length);
+		Datas = stationHub.Datas;
+		EmitSignal(SignalName.OnReadyFinished);
+	}
 
 	public void OnQuitPressed()
 	{

--- a/UI/ShipBuilder/Scenes/ShipBuilderTab.tscn
+++ b/UI/ShipBuilder/Scenes/ShipBuilderTab.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=15 format=3 uid="uid://bek4qr7p7b0d7"]
+[gd_scene load_steps=9 format=3 uid="uid://bek4qr7p7b0d7"]
 
 [ext_resource type="Script" path="res://UI/ShipBuilder/Scripts/ShipBuilderManager.cs" id="1_0so5t"]
 [ext_resource type="Script" path="res://UI/ShipBuilder/Scripts/GridGenerator.cs" id="1_u6ua3"]
@@ -7,13 +7,7 @@
 [ext_resource type="Texture2D" uid="uid://cf34idvc4fjwl" path="res://Assets/UI/ValidTile.png" id="3_8jt0l"]
 [ext_resource type="Texture2D" uid="uid://cdxjsmhlnjd5f" path="res://Assets/UI/InvalidTile.png" id="4_p56wv"]
 [ext_resource type="Script" path="res://UI/ShipBuilder/Scripts/ShipComponents.cs" id="5_4r2wq"]
-[ext_resource type="Resource" uid="uid://d1wj1c1q8xjf4" path="res://Resources/ShipData/Arzo/Arzo Cockpit.tres" id="6_oqe7q"]
 [ext_resource type="Material" uid="uid://cscvae43ltjeu" path="res://addons/ColourPicker/ColourableMat.tres" id="7_gt8iq"]
-[ext_resource type="Resource" uid="uid://btsesvosi62ol" path="res://Resources/ShipData/Arzo/Arzo Fuel Tank.tres" id="7_yk4xg"]
-[ext_resource type="Resource" uid="uid://bn45f5ywhhqpf" path="res://Resources/ShipData/Arzo/Arzo Generator.tres" id="8_tr5fq"]
-[ext_resource type="Resource" uid="uid://50ho5luwhv1m" path="res://Resources/ShipData/Arzo/Arzo Gun.tres" id="9_5etr4"]
-[ext_resource type="Resource" uid="uid://bbcg4mu0p2j8l" path="res://Resources/ShipData/Arzo/Arzo Hull.tres" id="10_iyfwn"]
-[ext_resource type="Resource" uid="uid://dc0h7q8fch0n0" path="res://Resources/ShipData/Arzo/Arzo Thruster.tres" id="11_jup1b"]
 
 [node name="ShipBuilderTab" type="Control" node_paths=PackedStringArray("itemList", "gridGenerator", "shipStats", "colourpicker")]
 layout_mode = 3
@@ -227,7 +221,6 @@ theme_override_constants/separation = 10
 custom_minimum_size = Vector2(10, 200)
 layout_mode = 2
 script = ExtResource("5_4r2wq")
-datas = Array[Object]([ExtResource("6_oqe7q"), ExtResource("7_yk4xg"), ExtResource("8_tr5fq"), ExtResource("9_5etr4"), ExtResource("10_iyfwn"), ExtResource("11_jup1b")])
 name = NodePath("../ComponentInformation/ScrollContainer/Stats/Name")
 health = NodePath("../ComponentInformation/ScrollContainer/Stats/Health")
 defense = NodePath("../ComponentInformation/ScrollContainer/Stats/Defense")

--- a/UI/ShipBuilder/Scripts/ShipBuilderManager.cs
+++ b/UI/ShipBuilder/Scripts/ShipBuilderManager.cs
@@ -1,6 +1,7 @@
 using Godot;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 public partial class ShipBuilderManager : Control
 {
@@ -22,8 +23,11 @@ public partial class ShipBuilderManager : Control
 	[Export]
 	private ColorPickerButton colourpicker;
 
+	[Export]
+	private Menu stationMenu;
 
-	private Dictionary<int, ShipComponentData> itemListRef = new();
+
+	private ShipComponentData[] itemListRef;
 	private List<Piece> pieces = new();
 	private ShipComponentData preview;
 	private Sprite2D draggedPreview;
@@ -39,12 +43,18 @@ public partial class ShipBuilderManager : Control
 	private GridTile[] gridSquares;
 
 
-
-
 	public override void _Ready()
 	{
+		base._Ready();
+		stationMenu.OnReadyFinished += SetUp;
+	}
+
+
+	public void SetUp()
+	{
+		itemListRef = stationMenu.Datas;
 		pieceColour = new(0.51f, 0.502f, 0.486f, 1);
-		itemList.PopulateItemList();
+		itemList.PopulateItemList(itemListRef);
 		shipStats.PopulateList();
 		gridSquares = gridGenerator.GenerateGrid();
 		foreach (TextureRect cr in gridSquares)
@@ -85,7 +95,7 @@ public partial class ShipBuilderManager : Control
 				Rect2 itemRect = itemList.GetItemRect(i);
 				if (itemRect.HasPoint(atPosition))
 				{
-					ShipComponentData data = itemList.ItemListRef[i];
+					ShipComponentData data = itemList.ItemListRefData[i];
 					draggedPreview = new();
 					preview = data;
 					draggedPreview.Texture = data.Sprite;

--- a/UI/ShipBuilder/Scripts/ShipComponents.cs
+++ b/UI/ShipBuilder/Scripts/ShipComponents.cs
@@ -5,25 +5,22 @@ using System.Collections.Generic;
 public partial class ShipComponents : ItemList
 {
     [Export]
-    private ShipComponentData[] datas;
-    [Export]
     private Label name, health, defense, description;
     [Export]
     private BoxContainer infobox;
+    public Dictionary<int, ShipComponentData> ItemListRefData { get; private set; } = new();
 
-    public Dictionary<int, ShipComponentData> ItemListRef { get; private set; } = new();
-
-
-    public void PopulateItemList()
+    public void PopulateItemList(ShipComponentData[] datas)
     {
         Clear();
+        ItemListRefData.Clear();
         for (int i = 0; i < datas.Length; i++)
         {
             ShipComponentData data = datas[i];
             if (data != null)
             {
                 int index = AddItem(data.Name, data.Sprite);
-                ItemListRef[index] = data;
+                ItemListRefData.Add(index, data);
             }
         }
     }
@@ -31,7 +28,7 @@ public partial class ShipComponents : ItemList
     public void OnItemSelected(int index)
     {
         infobox.Visible = true;
-        ShipComponentData data = ItemListRef[index];
+        ShipComponentData data = ItemListRefData[index];
         name.Text = data.Name;
         health.Text = "Health: " + data.MaxHealth.ToString();
         defense.Text = "Defense: " + data.Defense.ToString();


### PR DESCRIPTION
# Context
Now the contents of the list (parts that can be found in a station) can be set in the station prefab. This will make it easier to have multiple stations with different components.

# Modified
Changed exports, so the only export needed is in station. Modified scripts include:  
* Station.cs
* Menu.cs
* ShipBuilderManager.cs
* ShipComponents.cs (this script is responsible for the list of parts in the ship builder)
