### PR TITLE
build ship fixes

### DIFF
--- a/Scenes/open_space.tscn
+++ b/Scenes/open_space.tscn
@@ -288,22 +288,18 @@ direction = Vector2(40, 40)
 [node name="Stations" type="Node2D" parent="."]
 
 [node name="Station" parent="Stations" instance=ExtResource("4_gkyib")]
-process_mode = 3
 position = Vector2(938, 1018)
 scale = Vector2(4.97656, 4.97656)
 
 [node name="Station2" parent="Stations" instance=ExtResource("4_gkyib")]
-process_mode = 3
 position = Vector2(-104, 4008)
 scale = Vector2(4.97656, 4.97656)
 
 [node name="Station3" parent="Stations" instance=ExtResource("4_gkyib")]
-process_mode = 3
 position = Vector2(2862, -1357)
 scale = Vector2(4.97656, 4.97656)
 
 [node name="Station4" parent="Stations" instance=ExtResource("4_gkyib")]
-process_mode = 3
 position = Vector2(4830, 2237)
 scale = Vector2(4.97656, 4.97656)
 

--- a/Ship/Scripts/Managers/CargoManager.cs
+++ b/Ship/Scripts/Managers/CargoManager.cs
@@ -2,7 +2,7 @@ using Godot;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-public partial class CargoManager
+public partial class CargoManager // to be added: reset method
 {
 	public delegate void CargoLostEventHandler(Dictionary<Cargo, int> lostCargoDict);
 

--- a/Ship/Scripts/Managers/FuelManager.cs
+++ b/Ship/Scripts/Managers/FuelManager.cs
@@ -17,6 +17,12 @@ public partial class FuelManager
 
 	public FuelManager() { }
 
+	public void Reset()
+	{
+		FuelCapacity = 0;
+		Fuel = 0;
+	}
+
 	public void AddFuel(float fuel)
 	{
 		fuel = Math.Max(fuel, 0);

--- a/Ship/Scripts/Managers/GunManager.cs
+++ b/Ship/Scripts/Managers/GunManager.cs
@@ -22,16 +22,28 @@ public partial class GunManager : IPowerable
 				break;
 			}
 		}
-		if (!gunAdded) { gunGroups.Add(new(gun)); }
+		if (!gunAdded) 
+		{ 
+			GunGroup newGroup = new(gun);
+			gunGroups.Add(newGroup); 
+			newGroup.GroupDestroyed += OnGunGroupDestroyed;
+		}
 		if (selectedGroup == null)
 		{
 			selectedGroup = gunGroups[0];
 		}
 	}
 
+	public void OnGunGroupDestroyed(GunGroup gunGroup)
+	{
+		gunGroup.GroupDestroyed -= OnGunGroupDestroyed;
+		if(!gunGroups.Contains(gunGroup)) return; 
+		gunGroups.Remove(gunGroup);
+	}
+
 	public int GetPowerDraw()
 	{
-		if(shooting) return selectedGroup.PowerDraw;
+	if(shooting && selectedGroup != null) return selectedGroup.PowerDraw;
 		return 0;
 	}
 
@@ -92,5 +104,15 @@ public partial class GunManager : IPowerable
 		}
 
 		selectedGroup = gunGroups[newIndex];
+	}
+
+	public void Reset()
+	{
+		foreach(GunGroup gg in gunGroups)
+		{
+			gg.GroupDestroyed -= OnGunGroupDestroyed;
+		}
+		gunGroups.Clear();
+		selectedGroup = null;
 	}
 }

--- a/Ship/Scripts/Managers/PowerManager.cs
+++ b/Ship/Scripts/Managers/PowerManager.cs
@@ -78,6 +78,14 @@ public partial class PowerManager : Node
 		EmitSignal(SignalName.PowerChanged, GetPowerPercentage());
 	}
 
+	public void Reset()
+	{
+		generators.Clear();
+		MaxPower = GetMaxPowerGenerated();
+		CalculateEfficiency();
+		Power = Math.Min(MaxPower, Power);
+	}
+
 	private void OnGeneratorDestroyed(ShipComponent shipComponent)
 	{
 		if(shipComponent is not Generator generator) {GD.PushError("non generator component sent to power manager on destroy event"); return;}
@@ -114,6 +122,7 @@ public partial class PowerManager : Node
 	private float CalculateEfficiency()
 	{
 		Efficiency = 0;
+		if(generators.Count <= 0) return Efficiency;
 		foreach(Generator generator in generators) Efficiency += generator.efficiency;
 		Efficiency /= generators.Count;
 		return Efficiency;

--- a/Ship/Scripts/Managers/ThrustManager.cs
+++ b/Ship/Scripts/Managers/ThrustManager.cs
@@ -140,6 +140,14 @@ public partial class ThrustManager : IPowerable
 		Force -= direction * dot;
 	}
 
+	public void Reset()
+	{
+		thrusters.Clear();
+		PotentialForwardThrust = 0;
+		UpdateThrust();
+		powerDraw = 0;
+	}
+
 	private void OnThrusterDestroyed(ShipComponent shipComponent)
 	{
 		if (shipComponent is not Thruster thruster) { GD.PushError("non thruster ship component sent to thrust manager on destroy event"); return; }

--- a/Ship/Scripts/PlayerShip.cs
+++ b/Ship/Scripts/PlayerShip.cs
@@ -119,13 +119,10 @@ public partial class PlayerShip : Ship, IShip
 			if (n is Camera2D) { continue; }
 			if (n is ShipComponent shipComponent)
 			{
-				GD.Print($"{shipComponent.Name} pre move, comp global pos: {shipComponent.GlobalPosition}\ncomp collider pos{shipComponent.collider.GlobalPosition}");
 				shipComponent.Position -= ToLocal(center);
-				GD.Print($"{shipComponent.Name} post move, comp global pos: {shipComponent.GlobalPosition}\ncomp collider pos{shipComponent.collider.GlobalPosition}");
 				shipComponent.collider.Owner = null; //prevents warning.
 				shipComponent.collider.Reparent(this);
 				shipComponent.collider.Owner = this;
-				GD.Print($"{shipComponent.Name} post reParent, comp global pos: {shipComponent.GlobalPosition}\ncomp collider pos{shipComponent.collider.GlobalPosition}");
 			}
 		}
 		Weight = shipComponents.Count;

--- a/Ship/Scripts/PlayerShip.cs
+++ b/Ship/Scripts/PlayerShip.cs
@@ -117,12 +117,15 @@ public partial class PlayerShip : Ship, IShip
 		foreach (Node n in GetChildren())
 		{
 			if (n is Camera2D) { continue; }
-			if (n is Node2D n2 && n is not SingleRunAnimation && n is not Shield) { n2.Position -= ToLocal(center); } // is not, for bandaid solution to prevent ship destruction anim from being off centre
 			if (n is ShipComponent shipComponent)
 			{
+				GD.Print($"{shipComponent.Name} pre move, comp global pos: {shipComponent.GlobalPosition}\ncomp collider pos{shipComponent.collider.GlobalPosition}");
+				shipComponent.Position -= ToLocal(center);
+				GD.Print($"{shipComponent.Name} post move, comp global pos: {shipComponent.GlobalPosition}\ncomp collider pos{shipComponent.collider.GlobalPosition}");
 				shipComponent.collider.Owner = null; //prevents warning.
 				shipComponent.collider.Reparent(this);
 				shipComponent.collider.Owner = this;
+				GD.Print($"{shipComponent.Name} post reParent, comp global pos: {shipComponent.GlobalPosition}\ncomp collider pos{shipComponent.collider.GlobalPosition}");
 			}
 		}
 		Weight = shipComponents.Count;
@@ -137,7 +140,14 @@ public partial class PlayerShip : Ship, IShip
 		GC.Collect();
 	}
 
-	protected override bool IsVitalComponent(ShipComponent shipComponent)
+    public override void Reset()
+    {
+		powerManager.Reset();
+		fuelManager.Reset();
+        base.Reset();
+    }
+
+    protected override bool IsVitalComponent(ShipComponent shipComponent)
 	{
 		// gun intentionally not included as vital atm
 		return shipComponent is Cockpit || shipComponent is Thruster || shipComponent is Generator || shipComponent is FuelTank;

--- a/Ship/Scripts/Ship.cs
+++ b/Ship/Scripts/Ship.cs
@@ -163,10 +163,10 @@ public partial class Ship : CharacterBody2D, IShip
 	/// <summary>
 	/// Removes all ShipComponents from the ship. Used when reusing ship.
 	/// </summary>
-	public void Reset() //Change it to be better, maybe keep track of old parts before trybuild and replace if it fails?
+	public virtual void Reset() //Change it to be better, maybe keep track of old parts before trybuild and replace if it fails?
 	{
-		thrustManager = new(); //preferably a reset method that removes all existing thrusters
-		gunManager = new();
+		thrustManager.Reset();
+		gunManager.Reset();
 		Node[] children = GetChildren().ToArray();
 		for (int i = 0; i < children.Length; i++)
 		{
@@ -177,6 +177,7 @@ public partial class Ship : CharacterBody2D, IShip
 				component.Free();
 			}
 		}
+		shipComponents.Clear();
 	}
 
 	/// <summary>

--- a/Ship/ShipComponents/Generator.tscn
+++ b/Ship/ShipComponents/Generator.tscn
@@ -1,9 +1,24 @@
-[gd_scene load_steps=3 format=3 uid="uid://br8hk0g01ph4a"]
+[gd_scene load_steps=5 format=3 uid="uid://br8hk0g01ph4a"]
 
 [ext_resource type="PackedScene" uid="uid://b8yixlufb8hme" path="res://Ship/ShipComponents/ShipComponent.tscn" id="1_ygkwo"]
 [ext_resource type="Script" path="res://Ship/Scripts/Components/Generator.cs" id="2_xhv8o"]
+[ext_resource type="Shader" path="res://addons/ColourPicker/ColorPicker.gdshader" id="3_j165m"]
+
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_nxius"]
+resource_local_to_scene = true
+shader = ExtResource("3_j165m")
+shader_parameter/color = Color(0.509804, 0.501961, 0.486275, 1)
+shader_parameter/shades = PackedColorArray(0.690196, 0.690196, 0.690196, 1, 0.635294, 0.635294, 0.635294, 1, 0.552941, 0.552941, 0.552941, 1, 0.435294, 0.435294, 0.435294, 1, 0.356863, 0.356863, 0.356863, 1, 0.333333, 0.333333, 0.333333, 1)
+shader_parameter/tolerance = 0.001
 
 [node name="Generator" instance=ExtResource("1_ygkwo")]
 script = ExtResource("2_xhv8o")
 efficiency = 1.0
 maxPowerGenerated = 100
+
+[node name="Sprite" parent="." index="3"]
+material = SubResource("ShaderMaterial_nxius")
+shaderMat = SubResource("ShaderMaterial_nxius")
+
+[node name="DestroyedSprite" parent="." index="4"]
+shaderMat = SubResource("ShaderMaterial_nxius")

--- a/Ship/ShipComponents/Thruster.tscn
+++ b/Ship/ShipComponents/Thruster.tscn
@@ -1,8 +1,16 @@
-[gd_scene load_steps=10 format=3 uid="uid://cvjo3o6k4j254"]
+[gd_scene load_steps=12 format=3 uid="uid://cvjo3o6k4j254"]
 
 [ext_resource type="PackedScene" uid="uid://b8yixlufb8hme" path="res://Ship/ShipComponents/ShipComponent.tscn" id="1_fpp3g"]
 [ext_resource type="Script" path="res://Ship/Scripts/Components/Thruster.cs" id="2_e55n0"]
 [ext_resource type="Texture2D" uid="uid://beaghydkn6hxq" path="res://Assets/Ship/Thruster-animation.png" id="3_6duj7"]
+[ext_resource type="Shader" path="res://addons/ColourPicker/ColorPicker.gdshader" id="3_i721f"]
+
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_nog6n"]
+resource_local_to_scene = true
+shader = ExtResource("3_i721f")
+shader_parameter/color = Color(0.509804, 0.501961, 0.486275, 1)
+shader_parameter/shades = PackedColorArray(0.690196, 0.690196, 0.690196, 1, 0.635294, 0.635294, 0.635294, 1, 0.552941, 0.552941, 0.552941, 1, 0.435294, 0.435294, 0.435294, 1, 0.356863, 0.356863, 0.356863, 1, 0.333333, 0.333333, 0.333333, 1)
+shader_parameter/tolerance = 0.001
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_lkar3"]
 atlas = ExtResource("3_6duj7")
@@ -53,9 +61,16 @@ thrustAnim = NodePath("ThrustAnim")
 powerdraw = 100
 thrust = 400.0
 
+[node name="Sprite" parent="." index="3"]
+material = SubResource("ShaderMaterial_nog6n")
+shaderMat = SubResource("ShaderMaterial_nog6n")
+
 [node name="ThrustAnim" type="AnimatedSprite2D" parent="." index="4"]
 visible = false
 position = Vector2(0, 32)
 sprite_frames = SubResource("SpriteFrames_ch5lw")
 animation = &"thrust"
 frame_progress = 0.634195
+
+[node name="DestroyedSprite" parent="." index="5"]
+shaderMat = SubResource("ShaderMaterial_nog6n")

--- a/Structures/Station.cs
+++ b/Structures/Station.cs
@@ -75,6 +75,10 @@ public partial class Station : Sprite2D
 
 	private void ShrinkShip()
 	{
+		FinishedTweening(); 
+		// band aid solution to prevent issue with scaling causing offset on the physics colliders
+		// on the components
+		return;
 		tween = GetTree().CreateTween();
 		tween.SetPauseMode(Tween.TweenPauseMode.Process);
 		tween.TweenProperty(playerShip, "position", spritePos, 1f).SetTrans(Tween.TransitionType.Linear);
@@ -83,12 +87,14 @@ public partial class Station : Sprite2D
 	}
 	private void GrowShip()
 	{
+		OnGrowFinished();
+		return;
 		Tween tween = GetTree().CreateTween();
 		tween.SetPauseMode(Tween.TweenPauseMode.Process);
 		tween.TweenProperty(playerShip, "scale", OriginalScale, 0.8f).SetTrans(Tween.TransitionType.Linear);
-		tween.Finished += () => OnGrowFinished(tween);
+		tween.Finished += OnGrowFinished;
 	}
-	private void OnGrowFinished(Tween t)
+	private void OnGrowFinished()
 	{
 		popup.Visible = isOnBody;
 		GetTree().Paused = false;


### PR DESCRIPTION
# Context
fixed collider misalignment due to ship being built with 0 scale and then tweened to 1 scale. Also fixed ship state lingering on rebuild with added reset methods and component clear . Also made some weird material reference changes to some shipcomponent prefabs that i go from opening them. I suspect this is caused by it updating its inheritance from ShipComponent which means anybody should get this when opening them. So I will push this to prevent future conflicts.
# Modified
- added reset methods to:
 - FuelManager
 - GunManager
 - PowerManager
 - ThrustManager
- Ship made Reset virtual, called new reset methods in it and cleared components
- PlayerShip, added Reset override that calls the Reset on PlayerShip specific manager classes
- Station, removed shrink tween, temporarily using a return to leave the code in as the functionality is desired but causes collider misplacement
# Bug Fix
fixed #78 
